### PR TITLE
Update the link to the todo sample in the read me

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,7 +259,7 @@ Content:
 
 ### Sample Todo List app
 
-This sample can be found in the JetBrains Compose repository [here](https://github.com/arkivanov/Decompose/tree/master/sample/todo).
+This sample can be found in the JetBrains Compose repository [here](https://github.com/JetBrains/compose-jb/tree/master/examples/todoapp).
 
 It demonstrates the following features:
 - Multiplatform: Android, iOS and Desktop


### PR DESCRIPTION
The link for the Jetbrains compose todo app was being directed to a 404 site, simply updated this to point to the new repository location. 