### PR TITLE
Introduce StateKeeper, InstanceKeeper and BackPressedDispatcher builders for AndroidX

### DIFF
--- a/decompose/src/androidMain/kotlin/com/arkivanov/decompose/backpressed/AndroidExt.kt
+++ b/decompose/src/androidMain/kotlin/com/arkivanov/decompose/backpressed/AndroidExt.kt
@@ -3,6 +3,16 @@ package com.arkivanov.decompose.backpressed
 import androidx.activity.OnBackPressedCallback
 import androidx.activity.OnBackPressedDispatcher
 
+/**
+ * Creates a new instance of [BackPressedDispatcher] and attaches it to the provided [OnBackPressedDispatcher]
+ */
+fun BackPressedDispatcher(onBackPressedDispatcher: OnBackPressedDispatcher): BackPressedDispatcher =
+    DelegatedBackPressedDispatcher(onBackPressedDispatcher)
+
+@Deprecated(
+    "Use BackPressedDispatcher(OnBackPressedDispatcher) builder function",
+    ReplaceWith("BackPressedDispatcher(this)")
+)
 fun OnBackPressedDispatcher.toBackPressedDispatcher(): BackPressedDispatcher = DelegatedBackPressedDispatcher(this)
 
 private class DelegatedBackPressedDispatcher(

--- a/decompose/src/androidMain/kotlin/com/arkivanov/decompose/instancekeeper/AndroidExt.kt
+++ b/decompose/src/androidMain/kotlin/com/arkivanov/decompose/instancekeeper/AndroidExt.kt
@@ -6,9 +6,12 @@ import androidx.lifecycle.ViewModelStore
 
 private const val KEY_VIEW_MODEL = "STATE_KEEPER_VIEW_MODEL"
 
-fun ViewModelStore.toInstanceKeeper(): InstanceKeeper =
+/**
+ * Creates a new instance of [InstanceKeeper] and attaches it to the provided [ViewModelStore]
+ */
+fun InstanceKeeper(viewModelStore: ViewModelStore): InstanceKeeper =
     ViewModelProvider(
-        this,
+        viewModelStore,
         object : ViewModelProvider.Factory {
             @Suppress("UNCHECKED_CAST")
             override fun <T : ViewModel?> create(modelClass: Class<T>): T = InstanceKeeperViewModel() as T
@@ -16,6 +19,9 @@ fun ViewModelStore.toInstanceKeeper(): InstanceKeeper =
     )
         .get(KEY_VIEW_MODEL, InstanceKeeperViewModel::class.java)
         .instanceKeeperDispatcher
+
+@Deprecated("Use InstanceKeeper(ViewModelStore) builder function", ReplaceWith("InstanceKeeper(this)"))
+fun ViewModelStore.toInstanceKeeper(): InstanceKeeper = InstanceKeeper(this)
 
 internal class InstanceKeeperViewModel : ViewModel() {
     val instanceKeeperDispatcher = InstanceKeeperDispatcher()

--- a/decompose/src/androidMain/kotlin/com/arkivanov/decompose/statekeeper/AndroidExt.kt
+++ b/decompose/src/androidMain/kotlin/com/arkivanov/decompose/statekeeper/AndroidExt.kt
@@ -5,10 +5,13 @@ import androidx.savedstate.SavedStateRegistry
 
 private const val KEY_STATE = "STATE_KEEPER_STATE"
 
-fun SavedStateRegistry.toStateKeeper(): StateKeeper {
-    val dispatcher = StateKeeperDispatcher(consumeRestoredStateForKey(KEY_STATE)?.getParcelable(KEY_STATE))
+/**
+ * Creates a new instance of [StateKeeper] and attaches it to the provided [SavedStateRegistry]
+ */
+fun StateKeeper(savedStateRegistry: SavedStateRegistry): StateKeeper {
+    val dispatcher = StateKeeperDispatcher(savedStateRegistry.consumeRestoredStateForKey(KEY_STATE)?.getParcelable(KEY_STATE))
 
-    registerSavedStateProvider(KEY_STATE) {
+    savedStateRegistry.registerSavedStateProvider(KEY_STATE) {
         Bundle().apply {
             putParcelable(KEY_STATE, dispatcher.save())
         }
@@ -16,3 +19,7 @@ fun SavedStateRegistry.toStateKeeper(): StateKeeper {
 
     return dispatcher
 }
+
+@Deprecated("Use StateKeeper(SavedStateRegistry) builder function", ReplaceWith("StateKeeper(this)"))
+fun SavedStateRegistry.toStateKeeper(): StateKeeper = StateKeeper(this)
+

--- a/extensions-compose-jetbrains/src/androidMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/RootComponentBuilder.kt
+++ b/extensions-compose-jetbrains/src/androidMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/RootComponentBuilder.kt
@@ -12,12 +12,12 @@ import androidx.savedstate.SavedStateRegistryOwner
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.InternalDecomposeApi
-import com.arkivanov.decompose.backpressed.toBackPressedDispatcher
+import com.arkivanov.decompose.backpressed.BackPressedDispatcher
 import com.arkivanov.decompose.extensions.compose.jetbrains.lifecycle.lifecycle
-import com.arkivanov.decompose.instancekeeper.toInstanceKeeper
+import com.arkivanov.decompose.instancekeeper.InstanceKeeper
 import com.arkivanov.decompose.lifecycle.MergedLifecycle
 import com.arkivanov.decompose.lifecycle.asDecomposeLifecycle
-import com.arkivanov.decompose.statekeeper.toStateKeeper
+import com.arkivanov.decompose.statekeeper.StateKeeper
 import androidx.lifecycle.Lifecycle as AndroidLifecycle
 
 @OptIn(InternalDecomposeApi::class)
@@ -35,9 +35,9 @@ fun <T> rememberRootComponent(
         val componentContext =
             DefaultComponentContext(
                 lifecycle?.asDecomposeLifecycle()?.let { MergedLifecycle(it, composableLifecycle) } ?: composableLifecycle,
-                savedStateRegistry.toStateKeeper(),
-                viewModelStore.toInstanceKeeper(),
-                onBackPressedDispatcher.toBackPressedDispatcher()
+                StateKeeper(savedStateRegistry),
+                InstanceKeeper(viewModelStore),
+                BackPressedDispatcher(onBackPressedDispatcher)
             )
 
         factory(componentContext)

--- a/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/RootComponentBuilder.kt
+++ b/extensions-compose-jetpack/src/main/java/com/arkivanov/decompose/extensions/compose/jetpack/RootComponentBuilder.kt
@@ -12,12 +12,12 @@ import androidx.savedstate.SavedStateRegistryOwner
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.InternalDecomposeApi
-import com.arkivanov.decompose.backpressed.toBackPressedDispatcher
+import com.arkivanov.decompose.backpressed.BackPressedDispatcher
 import com.arkivanov.decompose.extensions.compose.jetpack.lifecycle.lifecycle
-import com.arkivanov.decompose.instancekeeper.toInstanceKeeper
+import com.arkivanov.decompose.instancekeeper.InstanceKeeper
 import com.arkivanov.decompose.lifecycle.MergedLifecycle
 import com.arkivanov.decompose.lifecycle.asDecomposeLifecycle
-import com.arkivanov.decompose.statekeeper.toStateKeeper
+import com.arkivanov.decompose.statekeeper.StateKeeper
 import androidx.lifecycle.Lifecycle as AndroidLifecycle
 
 @OptIn(InternalDecomposeApi::class)
@@ -35,9 +35,9 @@ fun <T> rememberRootComponent(
         val componentContext =
             DefaultComponentContext(
                 lifecycle?.asDecomposeLifecycle()?.let { MergedLifecycle(it, composableLifecycle) } ?: composableLifecycle,
-                savedStateRegistry.toStateKeeper(),
-                viewModelStore.toInstanceKeeper(),
-                onBackPressedDispatcher.toBackPressedDispatcher()
+                StateKeeper(savedStateRegistry),
+                InstanceKeeper(viewModelStore),
+                BackPressedDispatcher(onBackPressedDispatcher)
             )
 
         factory(componentContext)

--- a/sample/counter/app-android/src/main/java/com/arkivanov/counter/app/MainActivity.kt
+++ b/sample/counter/app-android/src/main/java/com/arkivanov/counter/app/MainActivity.kt
@@ -12,13 +12,13 @@ import androidx.compose.ui.Modifier
 import com.arkivanov.counter.app.ui.ComposeAppTheme
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.ExperimentalDecomposeApi
-import com.arkivanov.decompose.backpressed.toBackPressedDispatcher
+import com.arkivanov.decompose.backpressed.BackPressedDispatcher
 import com.arkivanov.decompose.extensions.android.DefaultViewContext
 import com.arkivanov.decompose.extensions.android.child
 import com.arkivanov.decompose.extensions.compose.jetpack.rememberRootComponent
-import com.arkivanov.decompose.instancekeeper.toInstanceKeeper
+import com.arkivanov.decompose.instancekeeper.InstanceKeeper
 import com.arkivanov.decompose.lifecycle.asDecomposeLifecycle
-import com.arkivanov.decompose.statekeeper.toStateKeeper
+import com.arkivanov.decompose.statekeeper.StateKeeper
 import com.arkivanov.sample.counter.shared.root.CounterRootContainer
 import com.arkivanov.sample.counter.shared.ui.android.CounterRootView
 import com.arkivanov.sample.counter.shared.ui.compose.invoke
@@ -57,9 +57,9 @@ class MainActivity : AppCompatActivity() {
         val componentContext =
             DefaultComponentContext(
                 lifecycle = lifecycle,
-                stateKeeper = savedStateRegistry.toStateKeeper(),
-                instanceKeeper = viewModelStore.toInstanceKeeper(),
-                backPressedDispatcher = onBackPressedDispatcher.toBackPressedDispatcher()
+                stateKeeper = StateKeeper(savedStateRegistry),
+                instanceKeeper = InstanceKeeper(viewModelStore),
+                backPressedDispatcher = BackPressedDispatcher(onBackPressedDispatcher)
             )
 
         val root = CounterRootContainer(componentContext)


### PR DESCRIPTION
Also deprecated the following extension functions:
- `SavedStateRegistry.toStateKeeper()`
- `ViewModelStore.toInstanceKeeper()`
- `OnBackPressedDispatcher.toBackPressedDispatcher()`