### PR TITLE
Destroy default InstanceKeeper at the end of lifecycle

### DIFF
--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DefaultComponentContext.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/DefaultComponentContext.kt
@@ -3,35 +3,35 @@ package com.arkivanov.decompose
 import com.arkivanov.decompose.backpressed.BackPressedDispatcher
 import com.arkivanov.decompose.instancekeeper.InstanceKeeper
 import com.arkivanov.decompose.instancekeeper.InstanceKeeperDispatcher
+import com.arkivanov.decompose.instancekeeper.attachTo
 import com.arkivanov.decompose.lifecycle.Lifecycle
 import com.arkivanov.decompose.statekeeper.StateKeeper
 import com.arkivanov.decompose.statekeeper.StateKeeperDispatcher
 
 class DefaultComponentContext private constructor(
     override val lifecycle: Lifecycle,
-    override val stateKeeper: StateKeeper = StateKeeperDispatcher(),
-    override val instanceKeeper: InstanceKeeper = InstanceKeeperDispatcher(),
-    override val backPressedDispatcher: BackPressedDispatcher = BackPressedDispatcher(),
-    routerFactory: RouterFactory
+    override val stateKeeper: StateKeeper,
+    override val instanceKeeper: InstanceKeeper,
+    override val backPressedDispatcher: BackPressedDispatcher,
+    routerFactory: RouterFactory = DefaultRouterFactory(lifecycle, stateKeeper, instanceKeeper, backPressedDispatcher)
 ) : ComponentContext, RouterFactory by routerFactory {
 
     constructor(
         lifecycle: Lifecycle,
-        stateKeeper: StateKeeper = StateKeeperDispatcher(),
-        instanceKeeper: InstanceKeeper = InstanceKeeperDispatcher(),
-        backPressedDispatcher: BackPressedDispatcher = BackPressedDispatcher(),
+        stateKeeper: StateKeeper? = null,
+        instanceKeeper: InstanceKeeper? = null,
+        backPressedDispatcher: BackPressedDispatcher? = null,
     ) : this(
-        lifecycle,
-        stateKeeper,
-        instanceKeeper,
-        backPressedDispatcher,
-        DefaultRouterFactory(lifecycle, stateKeeper, instanceKeeper, backPressedDispatcher)
+        lifecycle = lifecycle,
+        stateKeeper = stateKeeper ?: StateKeeperDispatcher(),
+        instanceKeeper = instanceKeeper ?: InstanceKeeperDispatcher().attachTo(lifecycle),
+        backPressedDispatcher = backPressedDispatcher ?: BackPressedDispatcher()
     )
 
     constructor(lifecycle: Lifecycle) : this(
-        lifecycle,
-        StateKeeperDispatcher(),
-        InstanceKeeperDispatcher(),
-        BackPressedDispatcher()
+        lifecycle = lifecycle,
+        stateKeeper = null,
+        instanceKeeper = null,
+        backPressedDispatcher = null
     )
 }

--- a/decompose/src/commonMain/kotlin/com/arkivanov/decompose/instancekeeper/InstanceKeeperExt.kt
+++ b/decompose/src/commonMain/kotlin/com/arkivanov/decompose/instancekeeper/InstanceKeeperExt.kt
@@ -1,5 +1,8 @@
 package com.arkivanov.decompose.instancekeeper
 
+import com.arkivanov.decompose.lifecycle.Lifecycle
+import com.arkivanov.decompose.lifecycle.doOnDestroy
+
 inline fun <reified T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(key: Any, factory: () -> T): T {
     var instance: T? = get(key) as T?
     if (instance == null) {
@@ -11,3 +14,9 @@ inline fun <reified T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(key:
 }
 
 inline fun <reified T : InstanceKeeper.Instance> InstanceKeeper.getOrCreate(factory: () -> T): T = getOrCreate(T::class, factory)
+
+internal fun InstanceKeeperDispatcher.attachTo(lifecycle: Lifecycle): InstanceKeeperDispatcher {
+    lifecycle.doOnDestroy(::destroy)
+
+    return this
+}

--- a/extensions-compose-jetbrains/src/jvmMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/RootComponentBuilder.kt
+++ b/extensions-compose-jetbrains/src/jvmMain/kotlin/com/arkivanov/decompose/extensions/compose/jetbrains/RootComponentBuilder.kt
@@ -8,11 +8,9 @@ import com.arkivanov.decompose.InternalDecomposeApi
 import com.arkivanov.decompose.backpressed.BackPressedDispatcher
 import com.arkivanov.decompose.extensions.compose.jetbrains.lifecycle.lifecycle
 import com.arkivanov.decompose.instancekeeper.InstanceKeeper
-import com.arkivanov.decompose.instancekeeper.InstanceKeeperDispatcher
 import com.arkivanov.decompose.lifecycle.Lifecycle
 import com.arkivanov.decompose.lifecycle.MergedLifecycle
 import com.arkivanov.decompose.statekeeper.StateKeeper
-import com.arkivanov.decompose.statekeeper.StateKeeperDispatcher
 
 @OptIn(InternalDecomposeApi::class)
 @Composable
@@ -28,10 +26,10 @@ fun <T> rememberRootComponent(
     return remember {
         val componentContext =
             DefaultComponentContext(
-                lifecycle?.let { MergedLifecycle(it, composableLifecycle) } ?: composableLifecycle,
-                stateKeeper ?: StateKeeperDispatcher(),
-                instanceKeeper ?: InstanceKeeperDispatcher(),
-                backPressedDispatcher ?: BackPressedDispatcher()
+                lifecycle = lifecycle?.let { MergedLifecycle(it, composableLifecycle) } ?: composableLifecycle,
+                stateKeeper = stateKeeper,
+                instanceKeeper = instanceKeeper,
+                backPressedDispatcher = backPressedDispatcher
             )
 
         factory(componentContext)


### PR DESCRIPTION
Fixes #86 