### PR TITLE
add watch os as target to decompose

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,4 +54,4 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Build iOS
-        run: ./gradlew build --info -Ptargets=IOS,TVOS,MACOS_X64
+        run: ./gradlew build --info -Ptargets=IOS,TVOS,MACOS_X64,WATCHOS

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -72,7 +72,7 @@ jobs:
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PASSWORD: ${{ secrets.SIGNING_PASSWORD }}
-        run: ./gradlew publish -Ptargets=IOS,TVOS,MACOS_X64
+        run: ./gradlew publish -Ptargets=IOS,TVOS,MACOS_X64,WATCHOS
   close-staging-repository:
     name: Close staging repository
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 ![badge][badge-jvm]
 ![badge][badge-mac]
 ![badge][badge-tvos]
+![badge][badge-watchos]
 
 # Decompose
 
@@ -64,3 +65,4 @@ If you like this project you can always <a href="https://www.buymeacoffee.com/ar
 [badge-jvm]: http://img.shields.io/badge/platform-jvm-DB413D.svg?style=flat
 [badge-mac]: http://img.shields.io/badge/platform-macos-111111.svg?style=flat
 [badge-tvos]: http://img.shields.io/badge/platform-tvos-808080.svg?style=flat
+[badge-watchos]: http://img.shields.io/badge/platform-watchos-C0C0C0.svg?style=flat

--- a/build.gradle
+++ b/build.gradle
@@ -83,6 +83,12 @@ boolean setupMultiplatform(Project project, List<Target> targets = Target.values
         }
     }
 
+    doIfWatchosEnabled {
+        if (Target.WATCHOS in targets) {
+            setupMultiplatformWatchos(project)
+        }
+    }
+
     doIfTvosEnabled {
         if (Target.TVOS in targets) {
             setupMultiplatformTvos(project)
@@ -212,6 +218,24 @@ private void setupMultiplatformMacosX64(Project project) {
             }
 
             macosX64Test {
+                dependsOn nonAndroidTest
+                dependsOn nativeTest
+            }
+        }
+    }
+}
+
+private void setupMultiplatformWatchos(Project project) {
+    project.kotlin {
+        watchos()
+
+        sourceSets {
+            watchosMain {
+                dependsOn nonAndroidMain
+                dependsOn nativeMain
+            }
+
+            watchosTest {
                 dependsOn nonAndroidTest
                 dependsOn nativeTest
             }
@@ -439,6 +463,12 @@ void doIfIosEnabled(Closure block) {
 
 void doIfMacosX64Enabled(Closure block) {
     if (isTargetEnabled(Target.MACOS_X64)) {
+        block()
+    }
+}
+
+void doIfWatchosEnabled(Closure block) {
+    if (isTargetEnabled(Target.WATCHOS)) {
         block()
     }
 }

--- a/buildSrc/src/main/groovy/Target.groovy
+++ b/buildSrc/src/main/groovy/Target.groovy
@@ -5,5 +5,6 @@ enum Target {
     JS_LEGACY,
     IOS,
     MACOS_X64,
-    TVOS
+    TVOS,
+    WATCHOS
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,7 @@ Decompose is a Kotlin Multiplatform lifecycle-aware business logic components (a
 * iosX64, iosArm64
 * macosX64
 * tvosX64, tvosArm64
+* watchosArm32, watchosArm64, watchosX86, watchosX64
 * JavaScript
 
 ## Why Decompose? 


### PR DESCRIPTION
## Overview 

try to setup watchOS support by following similar pattern to tvOS

## Questions

I would like to add a sample for watchOS before merging, but would we need to also update MVI Kotlin to support watchOS? Or just good enough to merge as is and create another issue for making a sample? 

## Issue

[Issue #155](https://github.com/arkivanov/Decompose/issues/155)