### PR TITLE
Correct link address in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Here are some key concepts of the library, more details can be found in the docu
 
 ## Samples
 
-Check out the [project website](https://arkivanov.github.io/Decompose/getting-started/samples/) for a full description of each sample.
+Check out the [project website](https://arkivanov.github.io/Decompose/samples/) for a full description of each sample.
 
 ## Articles
 


### PR DESCRIPTION
I appreciate this project very much, and I found a wrong routing of jump links in the README.md file, specially corrected it according to my own understanding.